### PR TITLE
User-Specific Team View

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,6 @@ dataFromServer = {}
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        print(request.args)
         token = request.args.get('token')
 
         if not token:
@@ -78,9 +77,19 @@ def dashboard():
     dataFromServer = data
     return render_template('index.j2', page="dashboard", css="style", css2="style", dataFromServer=dataFromServer)
 
-@app.route('/team-view')
+@app.route('/team-view', methods=['GET'])
 @token_required
 def team_view():
+
+    teamID = request.args.get('teamID')
+    players = database.db_functions.get_roster_for_player_team(teamID)
+    team_name = database.db_functions.get_team_name_from_team_id(teamID)
+    league_info = database.db_functions.get_league_information_from_team_id(teamID)
+    dataFromServer = {
+        'players': players,
+        'teamName': team_name,
+        'leagueInfo': league_info
+    }
     return render_template('index.j2', page="team_view", css="style", css2="style", dataFromServer=dataFromServer)
 
 @app.route('/league-view')
@@ -92,7 +101,6 @@ def league_view():
 @token_required
 def join_league():
     leagues = database.db_functions.get_all_leagues()
-    print(leagues)
     dataFromServer = {
         "leagues": leagues
     }

--- a/database/db_functions.py
+++ b/database/db_functions.py
@@ -221,7 +221,7 @@ def get_roster_for_player_team(teamID: int) -> dict:
     cursor = cnx.cursor(dictionary=True)
     team_roster_query = """
     SELECT p.playerID as playerID, team, status, playerName,
-    position, gamesPlayed, goals, assists, shootoutGoals, hatTricks, 
+    position, gamesPlayed, points, goals, assists, shootoutGoals, hatTricks, 
     plusMinus, pointsPerGame, shorthandedGoals, penaltyMinutes, blocks, 
     wins, losses, overtimeLosses, shutOuts, goalsAllowedAverage, goalsAllowed, 
     saves, savePercentage, minutesPlayed  FROM teamsplayers
@@ -235,6 +235,11 @@ def get_roster_for_player_team(teamID: int) -> dict:
     results = cursor.fetchall()
     cursor.close()
     cnx.close()
+
+    # fix floating points that come back for goalsAllowedAverage, savePercentage
+    for result in results:
+        result['goalsAllowedAverage'] = str(result['goalsAllowedAverage'])
+        result['savePercentage'] = str(result['savePercentage'])
     return results
 
 # Get league information from team ID
@@ -267,7 +272,7 @@ def get_team_name_from_team_id(teamID: int) -> str:
     results = cursor.fetchone()
     cursor.close()
     cnx.close()
-    return results
+    return results['teamname']
 
 # Creates a new league in the database
 def create_league(new_league: dict):

--- a/database/db_functions.py
+++ b/database/db_functions.py
@@ -212,6 +212,13 @@ def select_available_players_in_league(leagueID: int) -> dict:
     cursor.close()
     cnx.close()
     return results
+
+# Pull the specific roster for a players team
+def get_roster_for_player_team(teamID: int) -> dict:
+    cnx = mysql.connctor.connect(**config)
+    cursor = cnx.cursor(dictionary=True)
+    team_roster_query = """
+    SELECT """
     
 
 # Creates a new league in the database

--- a/database/db_functions.py
+++ b/database/db_functions.py
@@ -215,11 +215,59 @@ def select_available_players_in_league(leagueID: int) -> dict:
 
 # Pull the specific roster for a players team
 def get_roster_for_player_team(teamID: int) -> dict:
-    cnx = mysql.connctor.connect(**config)
+
+    # connect to the database and run the query using the teamID
+    cnx = mysql.connector.connect(**config)
     cursor = cnx.cursor(dictionary=True)
     team_roster_query = """
-    SELECT """
-    
+    SELECT p.playerID as playerID, team, status, playerName,
+    position, gamesPlayed, goals, assists, shootoutGoals, hatTricks, 
+    plusMinus, pointsPerGame, shorthandedGoals, penaltyMinutes, blocks, 
+    wins, losses, overtimeLosses, shutOuts, goalsAllowedAverage, goalsAllowed, 
+    saves, savePercentage, minutesPlayed  FROM teamsplayers
+    INNER JOIN (
+        SELECT * FROM players
+    ) AS p ON p.playerID = teamsplayers.playerID
+    WHERE teamID = %s
+    """
+    team_roster_values = (int(teamID),)
+    cursor.execute(team_roster_query, team_roster_values)
+    results = cursor.fetchall()
+    cursor.close()
+    cnx.close()
+    return results
+
+# Get league information from team ID
+def get_league_information_from_team_id(teamID: int) -> dict:
+    cnx = mysql.connector.connect(**config)
+    cursor = cnx.cursor(dictionary=True)
+    get_league_information_query = """
+    SELECT leagues.leagueID as leagueID, leagueName, seasonEnds FROM leagues
+    INNER JOIN (
+        SELECT teamID, leagueID FROM teams WHERE teamID = %s
+    ) AS T ON T.leagueID = leagues.leagueID
+    LIMIT 0,1"""
+    get_league_information_values = (int(teamID),)
+    cursor.execute(get_league_information_query, get_league_information_values)
+    results = cursor.fetchone()
+    cursor.close()
+    cnx.close()
+
+    # convert league seasonEnds date
+    results['seasonEnds'] = results['seasonEnds'].strftime('%m/%d/%Y')
+    return results
+
+# Get team name from team ID
+def get_team_name_from_team_id(teamID: int) -> str:
+    cnx = mysql.connector.connect(**config)
+    cursor = cnx.cursor(dictionary=True)
+    get_team_name_query = "SELECT teamname FROM teams WHERE teamid = %s LIMIT 0,1"
+    get_team_name_values = (teamID,)
+    cursor.execute(get_team_name_query, get_team_name_values)
+    results = cursor.fetchone()
+    cursor.close()
+    cnx.close()
+    return results
 
 # Creates a new league in the database
 def create_league(new_league: dict):

--- a/database/scratch.sql
+++ b/database/scratch.sql
@@ -1,0 +1,5 @@
+SELECT p.playerID as playerID, team, status, playerName, position, gamesPlayed, goals, assists, shootoutGoals, hatTricks, plusMinus, pointsPerGame, shorthandedGoals, penaltyMinutes, blocks, wins, losses, overtimeLosses, shutOuts, goalsAllowedAverage, goalsAllowed, saves, savePercentage, minutesPlayed  FROM teamsplayers
+INNER JOIN (
+    SELECT * FROM players
+    ) AS p ON p.playerID = teamsplayers.playerID
+WHERE teamID = 3

--- a/database/scratch.sql
+++ b/database/scratch.sql
@@ -1,5 +1,5 @@
-SELECT p.playerID as playerID, team, status, playerName, position, gamesPlayed, goals, assists, shootoutGoals, hatTricks, plusMinus, pointsPerGame, shorthandedGoals, penaltyMinutes, blocks, wins, losses, overtimeLosses, shutOuts, goalsAllowedAverage, goalsAllowed, saves, savePercentage, minutesPlayed  FROM teamsplayers
+SELECT leagues.leagueID as leagueID, leagueName, seasonEnds FROM leagues
 INNER JOIN (
-    SELECT * FROM players
-    ) AS p ON p.playerID = teamsplayers.playerID
-WHERE teamID = 3
+    SELECT teamID, leagueID FROM teams WHERE teamID = 9
+    ) AS T ON T.leagueID = leagues.leagueID
+LIMIT 0,1;

--- a/src/dashboard_items/user_team_row.js
+++ b/src/dashboard_items/user_team_row.js
@@ -1,22 +1,7 @@
 export default class UserTeamRow extends React.Component {
 
-    handleTeamView = (event) => {
-        event.preventDefault();
-        const pageData = {
-            teamID: this.props[0]
-        }
-        const url = "/team-view?token=" + localStorage.getItem('usertoken');
-        fetch(url, {
-           method: 'POST',
-           headers: {
-               'Content-Type': 'application/json',
-           },
-           body: JSON.stringify(pageData)
-        })
-        .then((response) => response.json())
-        .then(data => {
-            console.log(data)
-        })
+    handleTeamView = () => {
+        window.location.href = "/team-view?token="+localStorage.getItem('usertoken')+"&teamID="+this.props[0];
     }
 
     render() {

--- a/src/dashboard_items/user_team_row.js
+++ b/src/dashboard_items/user_team_row.js
@@ -1,7 +1,22 @@
 export default class UserTeamRow extends React.Component {
 
-    handleTeamView = () => {
-        window.location.href = "/team-view?token="+localStorage.getItem('usertoken')+"&teamid="+this.props[0];
+    handleTeamView = (event) => {
+        event.preventDefault();
+        const pageData = {
+            teamID: this.props[0]
+        }
+        const url = "/team-view?token=" + localStorage.getItem('usertoken');
+        fetch(url, {
+           method: 'POST',
+           headers: {
+               'Content-Type': 'application/json',
+           },
+           body: JSON.stringify(pageData)
+        })
+        .then((response) => response.json())
+        .then(data => {
+            console.log(data)
+        })
     }
 
     render() {

--- a/src/team/goalie_row.js
+++ b/src/team/goalie_row.js
@@ -3,24 +3,24 @@ import PlayerFunctions from "./player_functions.js";
 export default class GoalieRow extends React.Component {
     render() {
         return <tr>
-            <td>{this.props.name}</td>
-            <td>-</td>
-            <td>-</td>
+            <td>{this.props.playerName}</td>
+            <td>{this.props.team}</td>
+            <td>{this.props.status}</td>
             <td>{this.props.playerID}</td>
             <td>{this.props.position}</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
+            <td>{this.props.gamesPlayed}</td>
+            <td>{this.props.goals}</td>
+            <td>{this.props.assists}</td>
+            <td>{this.props.points}</td>
+            <td>{this.props.wins}</td>
+            <td>{this.props.losses}</td>
+            <td>{this.props.overtimeLosses}</td>
+            <td>{this.props.shutOuts}</td>
+            <td>{this.props.goalsAllowedAverage}</td>
+            <td>{this.props.goalsAllowed}</td>
+            <td>{this.props.saves}</td>
+            <td>{this.props.savePercentage}</td>
+            <td>{this.props.minutesPlayed}</td>
             <td>                
                 <PlayerFunctions />
             </td>

--- a/src/team/player_row.js
+++ b/src/team/player_row.js
@@ -3,22 +3,23 @@ import PlayerFunctions from './player_functions.js'
 export default class PlayerRow extends React.Component {
     render() {
         return <tr>
-            <td>{this.props.name}</td>
-            <td>-</td>
-            <td>-</td>
+            <td>{this.props.playerName}</td>
+            <td>{this.props.team}</td>
+            <td>{this.props.status}</td>
             <td>{this.props.playerID}</td>
             <td>{this.props.position}</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
-            <td>-</td>
+            <td>{this.props.gamesPlayed}</td>
+            <td>{this.props.goals}</td>
+            <td>{this.props.assists}</td>
+            <td>{this.props.points}</td>
+            <td>{this.props.shootoutGoals}</td>
+            <td>{this.props.hatTricks}</td>
+            <td>{this.props.plusMinus}</td>
+            <td>{this.props.pointsPerGame}</td>
+            <td>{this.props.shorthandedGoals}</td>
+            <td>{this.props.penaltyMinutes}</td>
+            <td>{this.props.blocks}</td>
+
             <td>
                 <PlayerFunctions />
             </td>

--- a/src/team/roster.js
+++ b/src/team/roster.js
@@ -1,13 +1,6 @@
 import PlayerRow from './player_row.js'
 import GoalieRow from './goalie_row.js'
 export default class Roster extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state ={
-            players: this.props.data.players
-        }
-    }
-
     render() {
         return <div className='roster'>
             <div className='roster-title'>
@@ -40,8 +33,8 @@ export default class Roster extends React.Component {
                 </tr>
             </thead>
             <tbody>
-            {this.state.players.map(element =>
-                    { if (element.position !== "G") 
+            {this.props.players.map(element =>
+                    { if (element.position !== "Goalie") 
                     return <PlayerRow key={element.playerID} {...element}/>
                     }
                     )}
@@ -77,8 +70,8 @@ export default class Roster extends React.Component {
                 </tr>
             </thead>
             <tbody>
-                {this.state.players.map(element =>
-                    { if (element.position === "G") 
+                {this.props.players.map(element =>
+                    { if (element.position === "Goalie") 
                     return <GoalieRow key={element.playerID} {...element}/>
                     }
                     )}

--- a/src/team/team_information.js
+++ b/src/team/team_information.js
@@ -1,19 +1,15 @@
 export default class TeamInformation extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = this.props.data.teamInformation
-    }
     render() {
     return <div className="team-info">
         <div className="team-info-primary">
             <div className="team-info-header">
-                <img className='team-info-image' src={'/static/img/' + this.state.teamLogo} />
+                <img className='team-info-image' src={'/static/img/hockey1_unsplash.jpg'} />
             </div>
             <div className='team-info-text'>
-                <h1>{this.state.teamName}</h1>
-                <p>Created: {this.state.createdOn}</p>
-                <p>League: {this.state.leagueName}</p>
-                <p>League ID: {this.state.leagueID}</p>
+                <h1>{this.props.teamName}</h1>
+                <p>Season Ends: {this.props.leagueInfo.seasonEnds}</p>
+                <p>League: {this.props.leagueInfo.leagueName}</p>
+                <p>League ID: {this.props.leagueInfo.leagueID}</p>
             </div>
         </div>
         <div className="team-info-subheader">

--- a/src/team_view.js
+++ b/src/team_view.js
@@ -3,15 +3,17 @@ import TeamInformation from './team/team_information.js'
 import NavBar from './nav_bar.js'
 import data from '../json/data.js'
 
-// window.history.replaceState({}, document.title, "/team-view");
-
 class TeamView extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = dataFromServer
+    }
     render() {
         return <div className='background-filter'>
             <NavBar />
             <div className='container'>
-                <TeamInformation data={data} />
-                <Roster data={data} />
+                <TeamInformation {...this.state} />
+                <Roster {...this.state} />
             </div>
         </div>
     }

--- a/static/js/dashboard_items/user_team_row.js
+++ b/static/js/dashboard_items/user_team_row.js
@@ -20,73 +20,58 @@ var UserTeamRow = function (_React$Component) {
             args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = UserTeamRow.__proto__ || Object.getPrototypeOf(UserTeamRow)).call.apply(_ref, [this].concat(args))), _this), _this.handleTeamView = function (event) {
-            event.preventDefault();
-            var pageData = {
-                teamID: _this.props[0]
-            };
-            var url = "/team-view?token=" + localStorage.getItem('usertoken');
-            fetch(url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(pageData)
-            }).then(function (response) {
-                return response.json();
-            }).then(function (data) {
-                console.log(data);
-            });
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = UserTeamRow.__proto__ || Object.getPrototypeOf(UserTeamRow)).call.apply(_ref, [this].concat(args))), _this), _this.handleTeamView = function () {
+            window.location.href = "/team-view?token=" + localStorage.getItem('usertoken') + "&teamID=" + _this.props[0];
         }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 
     _createClass(UserTeamRow, [{
-        key: 'render',
+        key: "render",
         value: function render() {
             return React.createElement(
-                'tr',
+                "tr",
                 null,
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     React.createElement(
-                        'button',
+                        "button",
                         { onClick: this.handleTeamView },
-                        'View'
+                        "View"
                     )
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props[0]
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props[1]
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props.rank
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props.win
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props.loss
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props.createdOn
                 ),
                 React.createElement(
-                    'td',
+                    "td",
                     null,
                     this.props[2]
                 )

--- a/static/js/dashboard_items/user_team_row.js
+++ b/static/js/dashboard_items/user_team_row.js
@@ -20,58 +20,73 @@ var UserTeamRow = function (_React$Component) {
             args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = UserTeamRow.__proto__ || Object.getPrototypeOf(UserTeamRow)).call.apply(_ref, [this].concat(args))), _this), _this.handleTeamView = function () {
-            window.location.href = "/team-view?token=" + localStorage.getItem('usertoken') + "&teamid=" + _this.props[0];
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = UserTeamRow.__proto__ || Object.getPrototypeOf(UserTeamRow)).call.apply(_ref, [this].concat(args))), _this), _this.handleTeamView = function (event) {
+            event.preventDefault();
+            var pageData = {
+                teamID: _this.props[0]
+            };
+            var url = "/team-view?token=" + localStorage.getItem('usertoken');
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(pageData)
+            }).then(function (response) {
+                return response.json();
+            }).then(function (data) {
+                console.log(data);
+            });
         }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 
     _createClass(UserTeamRow, [{
-        key: "render",
+        key: 'render',
         value: function render() {
             return React.createElement(
-                "tr",
+                'tr',
                 null,
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     React.createElement(
-                        "button",
+                        'button',
                         { onClick: this.handleTeamView },
-                        "View"
+                        'View'
                     )
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props[0]
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props[1]
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props.rank
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props.win
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props.loss
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props.createdOn
                 ),
                 React.createElement(
-                    "td",
+                    'td',
                     null,
                     this.props[2]
                 )

--- a/static/js/team/goalie_row.js
+++ b/static/js/team/goalie_row.js
@@ -26,17 +26,17 @@ var GoalieRow = function (_React$Component) {
                 React.createElement(
                     "td",
                     null,
-                    this.props.name
+                    this.props.playerName
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.team
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.status
                 ),
                 React.createElement(
                     "td",
@@ -51,67 +51,67 @@ var GoalieRow = function (_React$Component) {
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.gamesPlayed
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.goals
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.assists
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.points
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.wins
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.losses
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.overtimeLosses
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.shutOuts
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.goalsAllowedAverage
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.goalsAllowed
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.saves
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.savePercentage
                 ),
                 React.createElement(
                     "td",
                     null,
-                    "-"
+                    this.props.minutesPlayed
                 ),
                 React.createElement(
                     "td",

--- a/static/js/team/player_row.js
+++ b/static/js/team/player_row.js
@@ -26,17 +26,17 @@ var PlayerRow = function (_React$Component) {
                 React.createElement(
                     'td',
                     null,
-                    this.props.name
+                    this.props.playerName
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.team
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.status
                 ),
                 React.createElement(
                     'td',
@@ -51,57 +51,57 @@ var PlayerRow = function (_React$Component) {
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.gamesPlayed
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.goals
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.assists
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.points
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.shootoutGoals
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.hatTricks
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.plusMinus
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.pointsPerGame
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.shorthandedGoals
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.penaltyMinutes
                 ),
                 React.createElement(
                     'td',
                     null,
-                    '-'
+                    this.props.blocks
                 ),
                 React.createElement(
                     'td',

--- a/static/js/team/roster.js
+++ b/static/js/team/roster.js
@@ -12,15 +12,10 @@ import GoalieRow from './goalie_row.js';
 var Roster = function (_React$Component) {
     _inherits(Roster, _React$Component);
 
-    function Roster(props) {
+    function Roster() {
         _classCallCheck(this, Roster);
 
-        var _this = _possibleConstructorReturn(this, (Roster.__proto__ || Object.getPrototypeOf(Roster)).call(this, props));
-
-        _this.state = {
-            players: _this.props.data.players
-        };
-        return _this;
+        return _possibleConstructorReturn(this, (Roster.__proto__ || Object.getPrototypeOf(Roster)).apply(this, arguments));
     }
 
     _createClass(Roster, [{
@@ -280,8 +275,8 @@ var Roster = function (_React$Component) {
                         React.createElement(
                             'tbody',
                             null,
-                            this.state.players.map(function (element) {
-                                if (element.position !== "G") return React.createElement(PlayerRow, Object.assign({ key: element.playerID }, element));
+                            this.props.players.map(function (element) {
+                                if (element.position !== "Goalie") return React.createElement(PlayerRow, Object.assign({ key: element.playerID }, element));
                             })
                         )
                     )
@@ -565,8 +560,8 @@ var Roster = function (_React$Component) {
                         React.createElement(
                             'tbody',
                             null,
-                            this.state.players.map(function (element) {
-                                if (element.position === "G") return React.createElement(GoalieRow, Object.assign({ key: element.playerID }, element));
+                            this.props.players.map(function (element) {
+                                if (element.position === "Goalie") return React.createElement(GoalieRow, Object.assign({ key: element.playerID }, element));
                             })
                         )
                     )

--- a/static/js/team/team_information.js
+++ b/static/js/team/team_information.js
@@ -9,13 +9,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var TeamInformation = function (_React$Component) {
     _inherits(TeamInformation, _React$Component);
 
-    function TeamInformation(props) {
+    function TeamInformation() {
         _classCallCheck(this, TeamInformation);
 
-        var _this = _possibleConstructorReturn(this, (TeamInformation.__proto__ || Object.getPrototypeOf(TeamInformation)).call(this, props));
-
-        _this.state = _this.props.data.teamInformation;
-        return _this;
+        return _possibleConstructorReturn(this, (TeamInformation.__proto__ || Object.getPrototypeOf(TeamInformation)).apply(this, arguments));
     }
 
     _createClass(TeamInformation, [{
@@ -30,7 +27,7 @@ var TeamInformation = function (_React$Component) {
                     React.createElement(
                         "div",
                         { className: "team-info-header" },
-                        React.createElement("img", { className: "team-info-image", src: '/static/img/' + this.state.teamLogo })
+                        React.createElement("img", { className: "team-info-image", src: '/static/img/hockey1_unsplash.jpg' })
                     ),
                     React.createElement(
                         "div",
@@ -38,25 +35,25 @@ var TeamInformation = function (_React$Component) {
                         React.createElement(
                             "h1",
                             null,
-                            this.state.teamName
+                            this.props.teamName
                         ),
                         React.createElement(
                             "p",
                             null,
-                            "Created: ",
-                            this.state.createdOn
+                            "Season Ends: ",
+                            this.props.leagueInfo.seasonEnds
                         ),
                         React.createElement(
                             "p",
                             null,
                             "League: ",
-                            this.state.leagueName
+                            this.props.leagueInfo.leagueName
                         ),
                         React.createElement(
                             "p",
                             null,
                             "League ID: ",
-                            this.state.leagueID
+                            this.props.leagueInfo.leagueID
                         )
                     )
                 ),

--- a/static/js/team_view.js
+++ b/static/js/team_view.js
@@ -11,15 +11,16 @@ import TeamInformation from './team/team_information.js';
 import NavBar from './nav_bar.js';
 import data from '../json/data.js';
 
-// window.history.replaceState({}, document.title, "/team-view");
-
 var TeamView = function (_React$Component) {
     _inherits(TeamView, _React$Component);
 
-    function TeamView() {
+    function TeamView(props) {
         _classCallCheck(this, TeamView);
 
-        return _possibleConstructorReturn(this, (TeamView.__proto__ || Object.getPrototypeOf(TeamView)).apply(this, arguments));
+        var _this = _possibleConstructorReturn(this, (TeamView.__proto__ || Object.getPrototypeOf(TeamView)).call(this, props));
+
+        _this.state = dataFromServer;
+        return _this;
     }
 
     _createClass(TeamView, [{
@@ -32,8 +33,8 @@ var TeamView = function (_React$Component) {
                 React.createElement(
                     'div',
                     { className: 'container' },
-                    React.createElement(TeamInformation, { data: data }),
-                    React.createElement(Roster, { data: data })
+                    React.createElement(TeamInformation, this.state),
+                    React.createElement(Roster, this.state)
                 )
             );
         }


### PR DESCRIPTION
closes #13 

Database Functions

- Can now get team name from team id
- Can get a roster of players from a team id
- Can get league information from a team id

Front-End

- Dashboard/Team view button now sends a GET to /team-view with token and teamID
- TeamView/React State is populated with information received from server and bubbles down to the target components
- TeamView/Goalies and Players are separated correctly with correct stats listed from each from the server

Issues To Consider

- Some player names and other data fields are super long, and when the window is narrow (mobile), everything is crumpled together, might need to consider some UI improvements here